### PR TITLE
Removed is-svg resolution (dependabot issue)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "sass": "^1.70.0"
   },
   "resolutions": {
-    "is-svg": "4.2.2",
     "serialize-javascript": "3.1.0",
     "postcss": "8.2.10"
   }


### PR DESCRIPTION
This was listed in the resolutions, but i'm not sure it's even used