### PR TITLE
Support both legacy webchat and chat 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,12 @@ Note: If you're on a mobile device, tapping on the box will redirect you to your
 
 `tenant` - The name of your quiq tenant
 
-`options` - Your [web chat options](https://developers.goquiq.com/docs/webchat/#/getting_started/configuration?id=setting-web-chat-options) (You can skip the rest of the webchat setup)
+`options` - Options that will be used to initialize Quiq webchat.
+
+The recommended way to connect to your Quiq site is to add a `pageConfigurationId` that connects with Conversation Starter. However, you can still use legacy webchat by setting `contactPoint` instead.
+
+- If you're using Conversation Starter, you can find documentation [here](https://developers.goquiq.com/docs/conversation-starter/#/reference/sdk/main)
+- If you're still using legacy webchat, you can find documentation [here](https://developers.goquiq.com/docs/webchat/#/getting_started/configuration?id=setting-web-chat-options) instead.
 
 `useMobileChat` - Whether the options will show up on mobile (default is `false`)
 

--- a/src/__tests__/__snapshots__/rendering.test.js.snap
+++ b/src/__tests__/__snapshots__/rendering.test.js.snap
@@ -36,6 +36,7 @@ exports[`custom button color 1`] = `
     </div>
   </div>
   <button
+    class="legacy-chat"
     id="QuiqContactUsButton"
     style="background-color: orange;"
   >
@@ -211,6 +212,7 @@ exports[`rendering buttons 1`] = `
     </div>
   </div>
   <button
+    class="legacy-chat"
     id="QuiqContactUsButton"
     style="background-color: rgb(63, 70, 84);"
   >
@@ -386,6 +388,7 @@ exports[`rendering buttons 2`] = `
     </div>
   </div>
   <button
+    class="legacy-chat"
     id="QuiqContactUsButton"
     style="background-color: rgb(63, 70, 84);"
   >

--- a/src/__tests__/rendering.test.js
+++ b/src/__tests__/rendering.test.js
@@ -65,6 +65,27 @@ test('rendering buttons', async () => {
   expect(document.body).toMatchSnapshot()
 })
 
+test('legacy webchat', async () => {
+  await renderButtons({...testConfig})
+  expect(document.querySelector('#QuiqContactUsButton.legacy-chat')).not.toBeNull()
+})
+
+test('chat2.0 starts with button hidden', async () => {
+  const v2Config = {
+    ...testConfig,
+    channels: {
+      ...testConfig.channels,
+      webchat: {
+        tenant: 'nate',
+        options: {pageConfigurationId: 'default'},
+      },
+    },
+  }
+  await renderButtons(v2Config)
+  const button = document.querySelector('#QuiqContactUsButton')
+  expect(window.getComputedStyle(button).display).toBe('none')
+})
+
 test('showing SMS modal', async () => {
   await renderButtons({...testConfig})
 

--- a/src/__tests__/validation.test.js
+++ b/src/__tests__/validation.test.js
@@ -1,0 +1,15 @@
+import validateConfiguration from '../validateConfiguration'
+test('Setting both contactPoint and pageConfigurationId throws error', () => {
+  const configuration = {
+    channels: {
+      webchat: {
+        tenant: 'nate',
+        options: {contactPoint: 'default', pageConfigurationId: 'test-configuration'},
+      },
+    },
+    order: ['webchat'],
+  }
+  expect(() => validateConfiguration(configuration)).toThrowError(
+    "Both contactPoint and pageConfigurationId are set, but it's only valid to set one or the other. \nPlease set pageConfigurationId to use the current version of chat or contactPoint if you're using legacy webchat.",
+  )
+})

--- a/src/__tests__/webchatImport.test.js
+++ b/src/__tests__/webchatImport.test.js
@@ -3,10 +3,12 @@ import 'regenerator-runtime/runtime'
 import {getByText, fireEvent, waitFor} from '@testing-library/dom'
 import {TestScheduler} from 'jest'
 
-test('legacy webchat import', async () => {
+beforeEach(() => {
   window.Quiq = jest.fn()
   jest.spyOn(document.body, 'appendChild')
+})
 
+test('legacy webchat import', async () => {
   const testConfig = {
     channels: {
       webchat: {
@@ -22,6 +24,27 @@ test('legacy webchat import', async () => {
     expect(document.body.appendChild).toHaveBeenCalledWith(
       expect.objectContaining({
         src: 'https://nate.quiq-api.com/app/webchat/index.js',
+      }),
+    ),
+  )
+})
+
+test('chat 2.0 import', async () => {
+  const testConfig = {
+    channels: {
+      webchat: {
+        tenant: 'nate',
+        options: {pageConfigurationId: 'default'},
+      },
+    },
+    order: ['webchat'],
+  }
+  render({config: testConfig})
+
+  await waitFor(() =>
+    expect(document.body.appendChild).toHaveBeenCalledWith(
+      expect.objectContaining({
+        src: 'https://nate.quiq-api.com/app/chat-ui/index.js',
       }),
     ),
   )

--- a/src/__tests__/webchatImport.test.js
+++ b/src/__tests__/webchatImport.test.js
@@ -8,6 +8,12 @@ beforeEach(() => {
   jest.spyOn(document.body, 'appendChild')
 })
 
+afterEach(() => {
+  // delete window.Quiq
+  jest.restoreAllMocks()
+  document.body.innerHTML = ''
+})
+
 test('legacy webchat import', async () => {
   const testConfig = {
     channels: {
@@ -32,6 +38,9 @@ test('legacy webchat import', async () => {
 })
 
 test('chat 2.0 import', async () => {
+  window.Quiq = jest.fn()
+  jest.spyOn(document.body, 'appendChild')
+
   const testConfig = {
     channels: {
       webchat: {

--- a/src/__tests__/webchatImport.test.js
+++ b/src/__tests__/webchatImport.test.js
@@ -9,7 +9,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  // delete window.Quiq
+  delete window.Quiq
   jest.restoreAllMocks()
   document.body.innerHTML = ''
 })

--- a/src/__tests__/webchatImport.test.js
+++ b/src/__tests__/webchatImport.test.js
@@ -20,13 +20,15 @@ test('legacy webchat import', async () => {
   }
   render({config: testConfig})
 
-  await waitFor(() =>
+  await waitFor(() => {
     expect(document.body.appendChild).toHaveBeenCalledWith(
       expect.objectContaining({
         src: 'https://nate.quiq-api.com/app/webchat/index.js',
       }),
-    ),
-  )
+    )
+    fireEvent.load(document.querySelector('script'))
+    expect(window.Quiq).toHaveBeenCalledWith(testConfig.channels.webchat.options)
+  })
 })
 
 test('chat 2.0 import', async () => {
@@ -41,11 +43,13 @@ test('chat 2.0 import', async () => {
   }
   render({config: testConfig})
 
-  await waitFor(() =>
+  await waitFor(() => {
     expect(document.body.appendChild).toHaveBeenCalledWith(
       expect.objectContaining({
         src: 'https://nate.quiq-api.com/app/chat-ui/index.js',
       }),
-    ),
-  )
+    )
+    fireEvent.load(document.querySelector('script'))
+    expect(window.Quiq).toHaveBeenCalledWith(testConfig.channels.webchat.options)
+  })
 })

--- a/src/__tests__/webchatImport.test.js
+++ b/src/__tests__/webchatImport.test.js
@@ -1,0 +1,28 @@
+import render from '../render'
+import 'regenerator-runtime/runtime'
+import {getByText, fireEvent, waitFor} from '@testing-library/dom'
+import {TestScheduler} from 'jest'
+
+test('legacy webchat import', async () => {
+  window.Quiq = jest.fn()
+  jest.spyOn(document.body, 'appendChild')
+
+  const testConfig = {
+    channels: {
+      webchat: {
+        tenant: 'nate',
+        options: {contactPoint: 'default'},
+      },
+    },
+    order: ['webchat'],
+  }
+  render({config: testConfig})
+
+  await waitFor(() =>
+    expect(document.body.appendChild).toHaveBeenCalledWith(
+      expect.objectContaining({
+        src: 'https://nate.quiq-api.com/app/webchat/index.js',
+      }),
+    ),
+  )
+})

--- a/src/importWebchat.js
+++ b/src/importWebchat.js
@@ -1,7 +1,12 @@
 export default function importWebchat({tenant, options}) {
   return new Promise((resolve) => {
+    const shouldLoadV2 = !!options.pageConfigurationId
+
     const script = document.createElement('script')
-    script.setAttribute('src', `https://${tenant}.quiq-api.com/app/webchat/index.js`)
+    script.setAttribute(
+      'src',
+      `https://${tenant}.quiq-api.com/app/${shouldLoadV2 ? 'chat-ui' : 'webchat'}/index.js`,
+    )
     script.setAttribute('charset', 'UTF-8')
     script.onload = () => {
       resolve(Quiq(options))

--- a/src/render.js
+++ b/src/render.js
@@ -34,38 +34,32 @@ export default async function render({config: configuration, renderTarget = docu
     : Promise.resolve())
 
   // TODO : Cleanup this logic
-  if (useChatV2) {
+  if (chat && useChatV2) {
     window.chat = chat
-    if (chat) {
-      // Hide chat first. Otherwise, it will think it's supposed to be open and try to
-      // set up some things too early
-      chat.hide()
-      // When chat initializes, see if there's a conversation in progress already.
-      // If there is, just render that instead of the boxes
-      chat.on('statusChanged', async (event) => {
-        document.querySelector('#QuiqContactUsButton').style.display = 'none'
-        if (event.data.status === 'initialized') {
-          const status = (await chat.defaultWebchat.getState()).conversationStatus
-          if (status === 'webchatConversationStatusActive') {
-            launchWebchat()
-          } else {
-            document.querySelector('#QuiqContactUsButton').style.display = 'block'
+    // Hide chat first. Otherwise, it will think it's supposed to be open and try to
+    // set up some things too early
+    chat.hide()
+    // When chat initializes, see if there's a conversation in progress already.
+    // If there is, just render that instead of the boxes
+    chat.on('statusChanged', async (event) => {
+      document.querySelector('#QuiqContactUsButton').style.display = 'none'
+      if (event.data.status === 'initialized') {
+        const status = (await chat.defaultWebchat.getState()).conversationStatus
+        if (status === 'webchatConversationStatusActive') {
+          launchWebchat()
+        } else {
+          document.querySelector('#QuiqContactUsButton').style.display = 'block'
 
-            // Start the autoPop timer once chat is ready
-            if (config.autoPop) {
-              autoPop()
-            }
+          // Start the autoPop timer once chat is ready
+          if (config.autoPop) {
+            autoPop()
           }
         }
-      })
-    } else if (config.autoPop) {
-      // We don't need to wait for chat to load, so start the autoPop timer now
-      autoPop()
-    }
-  } else {
-    if (config.autoPop) {
-      autoPop()
-    }
+      }
+    })
+  } else if (config.autoPop) {
+    // We don't need to wait for chat to load, so start the autoPop timer now
+    autoPop()
   }
 
   var container = document.querySelector('#QuiqContactUsButtons .channelButtons')

--- a/src/render.js
+++ b/src/render.js
@@ -33,7 +33,6 @@ export default async function render({config: configuration, renderTarget = docu
     ? importWebchat(config.channels.webchat)
     : Promise.resolve())
 
-  // TODO : Cleanup this logic
   if (chat && useChatV2) {
     window.chat = chat
     // Hide chat first. Otherwise, it will think it's supposed to be open and try to

--- a/src/render.js
+++ b/src/render.js
@@ -15,16 +15,57 @@ var _timeout = undefined
 
 export default async function render({config: configuration, renderTarget = document.body}) {
   config = configuration
+
+  // Chat2.0 needs to do things a bit differently because of how it bootstraps
+  const useChatV2 =
+    config.order.includes('webchat') && !!config.channels.webchat?.options?.pageConfigurationId
+
   renderContainer({renderTarget})
-  renderMainButton({toggle, color: config.styles?.buttonColor, renderTarget})
+  renderMainButton({
+    toggle,
+    color: config.styles?.buttonColor,
+    renderTarget,
+    useChatV2,
+  })
   // Load external scripts if we need them
   await (config.order.includes('abc') ? importAppleScript() : Promise.resolve())
   chat = await (config.order.includes('webchat')
     ? importWebchat(config.channels.webchat)
     : Promise.resolve())
 
-  if (config.autoPop) {
-    autoPop()
+  // TODO : Cleanup this logic
+  if (useChatV2) {
+    window.chat = chat
+    if (chat) {
+      // Hide chat first. Otherwise, it will think it's supposed to be open and try to
+      // set up some things too early
+      chat.hide()
+      // When chat initializes, see if there's a conversation in progress already.
+      // If there is, just render that instead of the boxes
+      chat.on('statusChanged', async (event) => {
+        document.querySelector('#QuiqContactUsButton').style.display = 'none'
+        if (event.data.status === 'initialized') {
+          const status = (await chat.defaultWebchat.getState()).conversationStatus
+          if (status === 'webchatConversationStatusActive') {
+            launchWebchat()
+          } else {
+            document.querySelector('#QuiqContactUsButton').style.display = 'block'
+
+            // Start the autoPop timer once chat is ready
+            if (config.autoPop) {
+              autoPop()
+            }
+          }
+        }
+      })
+    } else if (config.autoPop) {
+      // We don't need to wait for chat to load, so start the autoPop timer now
+      autoPop()
+    }
+  } else {
+    if (config.autoPop) {
+      autoPop()
+    }
   }
 
   var container = document.querySelector('#QuiqContactUsButtons .channelButtons')
@@ -40,7 +81,7 @@ export default async function render({config: configuration, renderTarget = docu
         break
       case 'webchat':
         if (config.channels.webchat.useMobileChat || !isMobile()) {
-          button = _renderWebchat(totalChannels - i - 1)
+          button = _renderWebchat(totalChannels - i - 1, useChatV2)
         }
         break
       case 'facebook':
@@ -152,7 +193,12 @@ function _renderSms(i, modalRenderTarget) {
   }
 }
 
-function _renderWebchat(i) {
+/**
+ *
+ * @param {number} i The index of the button
+ * @param {boolean} useV2 If chat2.0 should be used
+ */
+function _renderWebchat(i, useV2) {
   var button = _renderBasicButton(
     i,
     'webchatButton',
@@ -160,7 +206,7 @@ function _renderWebchat(i) {
     'Web Chat',
   )
 
-  button.onclick = launchWebchat
+  button.onclick = () => launchWebchat(useV2)
   return button
 }
 
@@ -258,10 +304,18 @@ function _renderAbc(i) {
   return parent
 }
 
-function launchWebchat() {
+/**
+ * @param {boolean} useV2 If using chat2.0
+ */
+function launchWebchat(useV2) {
   document.querySelector('#QuiqContactUsButton').style.display = 'none'
   document.querySelector('#QuiqContactUsButtons').style.display = 'none'
-  chat.toggle()
+  if (useV2) {
+    document.body.classList.add('quiq-enable-chat')
+    chat.show()
+  } else {
+    chat.toggle()
+  }
 }
 
 function toggle() {

--- a/src/renderMainButton.js
+++ b/src/renderMainButton.js
@@ -1,8 +1,16 @@
-export default function renderMainButton({toggle, color, renderTarget}) {
+export default function renderMainButton({toggle, color, renderTarget, useChatV2}) {
   const button = document.createElement('button')
   button.id = 'QuiqContactUsButton'
   button.onclick = () => toggle()
   button.style.backgroundColor = color || '#3f4654'
+  if (useChatV2) {
+    // Hide the button at first if chat2.0 is loaded. Otherwise there can be a weird
+    // delay after selecting webchat if it's still initializing
+    button.style.display = 'none'
+  } else {
+    // Add a class for legacy chat. The button shows up in a slightly different spot
+    button.classList.add('legacy-chat')
+  }
 
   const icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
   icon.setAttribute('width', '30')

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -56,8 +56,8 @@
   align-items: center;
   position: fixed;
   box-sizing: border-box;
-  bottom: 24px;
-  right: 24px;
+  bottom: 1rem;
+  right: 1rem;
   width: 60px;
   height: 60px;
   color: #fff;
@@ -66,6 +66,11 @@
   transition: all 0.15s ease-in-out;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
   animation: chatButtonIn 0.3s ease-in-out 1;
+
+  &.legacy-chat {
+    bottom: 24px;
+    right: 24px;
+  }
 
   &.closed {
     animation: chatButtonOut 0.3s ease-in-out 1;

--- a/src/validateConfiguration.js
+++ b/src/validateConfiguration.js
@@ -41,6 +41,14 @@ export default function validateConfiguration(config) {
   if (config.channels.webchat && !config.channels.webchat.options) {
     warn('No webchat options were specified')
   }
+  if (
+    config.channels.webchat?.options?.contactPoint &&
+    config.channels.webchat?.options?.pageConfigurationId
+  ) {
+    throw new Error(
+      "Both contactPoint and pageConfigurationId are set, but it's only valid to set one or the other. \nPlease set pageConfigurationId to use the current version of chat or contactPoint if you're using legacy webchat.",
+    )
+  }
 
   if (config.channels.facebook && !config.channels.facebook.id) {
     warnLoudly('id is required when using Facebook')

--- a/test.html
+++ b/test.html
@@ -30,7 +30,8 @@
           },
           webchat: {
             tenant: 'nate',
-            options: {contactPoint: 'default'},
+            // options: {contactPoint: 'default'},
+            options: {pageConfigurationId: 'test-configuration'},
           },
           facebook: {
             id: 'your-facebook-id',

--- a/test.html
+++ b/test.html
@@ -30,8 +30,8 @@
           },
           webchat: {
             tenant: 'nate',
-            // options: {contactPoint: 'default'},
-            options: {pageConfigurationId: 'test-configuration'},
+            options: {contactPoint: 'default'},
+            // options: {pageConfigurationId: 'test-configuration'},
           },
           facebook: {
             id: 'your-facebook-id',
@@ -40,6 +40,7 @@
             appleBusinessId: 'your-apple-business-id',
           },
         },
+        // order: ['whatsApp', 'sms', 'facebook', 'abc'],
         order: ['whatsApp', 'sms', 'facebook', 'abc', 'webchat'],
         autoPop: {
           message: 'See Quiq in action.  Ask a question or start a conversation now.',

--- a/test.html
+++ b/test.html
@@ -30,8 +30,8 @@
           },
           webchat: {
             tenant: 'nate',
-            options: {contactPoint: 'default'},
-            // options: {pageConfigurationId: 'test-configuration'},
+            // options: {contactPoint: 'default'},
+            options: {pageConfigurationId: 'test-configuration'},
           },
           facebook: {
             id: 'your-facebook-id',
@@ -48,20 +48,21 @@
         },
       })
 
-      window.QuiqContactUs.render().then(() => {
-        window.QuiqContactUs.reconfigure({
-          channels: {
-            webchat: {
-              options: {
-                height: 'calc(100vh - 106px)',
-                colors: {
-                  primary: 'purple',
-                },
-              },
-            },
-          },
-        })
-      })
+      window.QuiqContactUs.render()
+      // .then(() => {
+      //   window.QuiqContactUs.reconfigure({
+      //     channels: {
+      //       webchat: {
+      //         options: {
+      //           height: 'calc(100vh - 106px)',
+      //           colors: {
+      //             primary: 'purple',
+      //           },
+      //         },
+      //       },
+      //     },
+      //   })
+      // })
     </script>
     <h1>Test page</h1>
   </body>

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,7 +24,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz"
   integrity sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==
 
-"@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.23.9", "@babel/core@^7.9.6":
+"@babel/core@^7.0.0", "@babel/core@^7.0.0-0", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.13.0", "@babel/core@^7.23.9", "@babel/core@^7.4.0-0", "@babel/core@^7.8.0", "@babel/core@^7.9.6":
   version "7.26.10"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz"
   integrity sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==
@@ -1238,7 +1238,7 @@
   resolved "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.1.tgz"
   integrity sha512-S6oPal772qJZHoRZLFc/XoZW2gFvwXusYUmXPXkgxJLuEk2vOt7jc4Yo6z/vtI0EBkbPBVrJJ0B+prLIKiWqHg==
 
-"@types/babel__core@^7.1.14":
+"@types/babel__core@^7.1.14", "@types/babel__core@^7.1.9":
   version "7.1.14"
   resolved "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz"
   integrity sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==
@@ -1570,7 +1570,7 @@ braces@^3.0.3, braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.0.0, browserslist@^4.21.4, browserslist@^4.24.0, browserslist@^4.24.4:
+browserslist@^4.0.0, browserslist@^4.21.4, browserslist@^4.24.0, browserslist@^4.24.4, "browserslist@>= 4.21.0":
   version "4.24.4"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz"
   integrity sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==
@@ -1716,11 +1716,6 @@ colord@^2.9.1:
   version "2.9.3"
   resolved "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz"
   integrity sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==
-
-colorette@^1.2.2:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.4.0.tgz#5190fbb87276259a86ad700bff2c6d6faa3fca40"
-  integrity sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==
 
 combined-stream@^1.0.8:
   version "1.0.8"
@@ -1917,7 +1912,7 @@ data-urls@^3.0.2:
     whatwg-mimetype "^3.0.0"
     whatwg-url "^11.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
+debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@4:
   version "4.3.1"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -2774,7 +2769,7 @@ jest-resolve-dependencies@^29.7.0:
     jest-regex-util "^29.6.3"
     jest-snapshot "^29.7.0"
 
-jest-resolve@^29.7.0:
+jest-resolve@*, jest-resolve@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz"
   integrity sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==
@@ -3146,9 +3141,9 @@ ms@2.1.2:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-nanoid@^3.1.22, nanoid@^3.3.8:
+nanoid@^3.3.8:
   version "3.3.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
 
 natural-compare@^1.4.0:
@@ -3606,16 +3601,7 @@ postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@8.2.10:
-  version "8.2.10"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.10.tgz#ca7a042aa8aff494b334d0ff3e9e77079f6f702b"
-  integrity sha512-b/h7CPV7QEdrqIxtAf2j31U5ef05uBDuvoXv6L51Q4rcS1jdlXAVKJv+atCFdUXYl9dyTHGyoMzIepwowRJjFw==
-  dependencies:
-    colorette "^1.2.2"
-    nanoid "^3.1.22"
-    source-map "^0.6.1"
-
-postcss@^8.2.15:
+postcss@^8.0.0, postcss@^8.0.9, postcss@^8.1.0, postcss@^8.2.15, postcss@^8.2.2, postcss@8.x:
   version "8.5.3"
   resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz"
   integrity sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==
@@ -3677,13 +3663,6 @@ querystringify@^2.1.1:
   version "2.2.0"
   resolved "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz"
   integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
-
-randombytes@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
-  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
-  dependencies:
-    safe-buffer "^5.1.0"
 
 react-is@^17.0.1:
   version "17.0.2"
@@ -3821,17 +3800,12 @@ rollup-pluginutils@^2.8.2:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^2.48.0:
+rollup@^1.20.0||^2.0.0, rollup@^2.48.0:
   version "2.79.2"
   resolved "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz"
   integrity sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==
   optionalDependencies:
     fsevents "~2.3.2"
-
-safe-buffer@^5.1.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-identifier@^0.4.2:
   version "0.4.2"
@@ -3864,17 +3838,15 @@ semver@^6.1.1, semver@^6.1.2, semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.5.3, semver@^7.5.4:
+semver@^7.5.3:
   version "7.7.1"
   resolved "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz"
   integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
 
-serialize-javascript@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.1.0.tgz#8bf3a9170712664ef2561b44b691eafe399214ea"
-  integrity sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==
-  dependencies:
-    randombytes "^2.1.0"
+semver@^7.5.4:
+  version "7.7.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz"
+  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -3903,7 +3875,7 @@ slash@^3.0.0:
   resolved "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.2.1:
+source-map-js@^1.2.1, "source-map-js@>=0.6.2 <2.0.0":
   version "1.2.1"
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==


### PR DESCRIPTION
Adding support for both legacy webchat and chat 2.0 in the same build.

The decider will be whether the `contactPoint` or `pageConfigurationId` is set in the configuration